### PR TITLE
Fix matrix multiply implementation

### DIFF
--- a/include/target/riscv/lsu/lsu.hpp
+++ b/include/target/riscv/lsu/lsu.hpp
@@ -145,7 +145,7 @@ VILL::vpu_return_t store_eew(
     uint64_t emul_num,          //!< Effective register multiplicity numerator
     uint64_t emul_denom,        //!< Effective register multiplicity denominator
     uint16_t eew_bytes,         //!< Effective element width [bytes]
-    uint16_t vec_len,           //!< Vector length [elements]
+    uint32_t vec_len,           //!< Vector length [elements]
     uint16_t vec_reg_len_bytes, //!< Vector register length [bytes]
     uint16_t src_vec_reg,       //!< Source vector register [index]
     uint64_t dst_mem_start,     //!< Destination memory start address

--- a/include/target/riscv/lsu/lsu.hpp
+++ b/include/target/riscv/lsu/lsu.hpp
@@ -42,7 +42,7 @@ VILL::vpu_return_t load_eew(
     [[maybe_unused]] uint64_t const emul_num,   //!< Effective register multiplicity numerator
     [[maybe_unused]] uint64_t const emul_denom, //!< Effective register multiplicity denominator
     uint16_t const eew_bytes,                   //!< Effective element width [bytes]
-    uint16_t const vec_len,                     //!< Vector length [elements]
+    uint32_t const vec_len,                     //!< Vector length [elements]
     uint16_t const vec_reg_len_bytes,           //!< Vector register length [bytes]
     uint16_t const vd,                          //!< Destination vector [index]
     uint64_t const src_mem_start,               //!< Source memory start address

--- a/include/target/riscv/softvector.h
+++ b/include/target/riscv/softvector.h
@@ -847,6 +847,8 @@ extern "C"
 
     uint8_t vfmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
                        uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl, uint8_t const rounding_mode);
+    uint8_t vmtl_v(void *const vector_field, uint8_t *const memory, uint16_t const vtype, uint8_t pVm, uint16_t const vd, uint8_t const Llambda,
+                            uint32_t const ld, uint32_t vstart, uint32_t const vlen, uint32_t const vl);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/target/riscv/softvector.h
+++ b/include/target/riscv/softvector.h
@@ -847,7 +847,11 @@ extern "C"
 
     uint8_t vfmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
                        uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl, uint8_t const rounding_mode);
+
     uint8_t vmtl_v(void *const vector_field, uint8_t *const memory, uint16_t const vtype, uint8_t pVm, uint16_t const vd, uint8_t const Llambda,
+                            uint32_t const ld, uint32_t vstart, uint32_t const vlen, uint32_t const vl);
+
+    uint8_t vmts_v(void *const vector_field, uint8_t *const memory, uint16_t const vtype, uint8_t pVm, uint16_t const vs, uint8_t const Llambda,
                             uint32_t const ld, uint32_t vstart, uint32_t const vlen, uint32_t const vl);
 
 #ifdef __cplusplus

--- a/include/target/riscv/softvector.h
+++ b/include/target/riscv/softvector.h
@@ -75,6 +75,7 @@ extern "C"
     uint8_t vtype_extractMA(uint16_t const vtype //!<[in] vtype bitfield
     );
 
+
     //////////////////////////////////////////////////////////////////////////////////////
     /// \brief Concatenate MEW and WIDTH to EEW and return number of bits for EEW
     /// \return Decoded EEW [bits]
@@ -836,16 +837,16 @@ extern "C"
 
     // Matrix
     uint8_t vmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
-                      uint16_t const vs2, uint16_t const vstart, uint32_t const vlen);
+                      uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl);
 
     uint8_t vwmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
-                      uint16_t const vs2, uint16_t const vstart, uint32_t const vlen);
+                      uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl);
 
     uint8_t vqwmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
-                        uint16_t const vs2, uint16_t const vstart, uint32_t const vlen);
+                        uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl);
 
     uint8_t vfmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
-                       uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint8_t const rounding_mode);
+                       uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl, uint8_t const rounding_mode);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/target/riscv/lsu/lsu.cpp
+++ b/src/target/riscv/lsu/lsu.cpp
@@ -60,7 +60,7 @@ VILL::vpu_return_t VLSU::load_eew(VLSU::MemoryAccessFunction func_read_mem, uint
 }
 
 VILL::vpu_return_t VLSU::store_eew(VLSU::MemoryAccessFunction func_write_mem, uint8_t *vec_reg_mem, uint64_t emul_num,
-                                   uint64_t emul_denom, uint16_t eew_bytes, uint16_t vec_len,
+                                   uint64_t emul_denom, uint16_t eew_bytes, uint32_t vec_len,
                                    uint16_t vec_reg_len_bytes, uint16_t src_vec_reg, uint64_t dst_mem_start,
                                    uint16_t vec_elem_start, uint8_t mask_f, int16_t stride_bytes)
 {

--- a/src/target/riscv/lsu/lsu.cpp
+++ b/src/target/riscv/lsu/lsu.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <algorithm>
 #include <functional>
+#include <cstdio>
 
 #include "base/base.hpp"
 #include "base/softvector-platform-types.hpp"
@@ -31,7 +32,7 @@
 // TODO: Read/Write exceptions are currently ignored
 VILL::vpu_return_t VLSU::load_eew(VLSU::MemoryAccessFunction func_read_mem, uint8_t *const vector_field,
                                   uint64_t const emul_num, uint64_t const emul_denom, uint16_t const eew_bytes,
-                                  uint16_t const vec_len, uint16_t const vec_reg_len_bytes, uint16_t const vd,
+                                  uint32_t const vec_len, uint16_t const vec_reg_len_bytes, uint16_t const vd,
                                   uint64_t const src_mem_start, uint16_t const vstart, uint8_t const mask_f,
                                   int16_t const stride_bytes)
 {

--- a/src/target/riscv/softmatrix.cpp
+++ b/src/target/riscv/softmatrix.cpp
@@ -371,14 +371,42 @@ uint8_t vmtl_v(void *const vector_field, uint8_t *const memory, uint16_t const v
         const auto base_addr = (vtype_decoded.sew / 8) * ((addr / linesize) * effective_ld + addr % linesize);
         for (std::size_t i = 0; i < len; ++i){
             buff[i] = memory[base_addr + i];
-            if (vtype_decoded.sew == 8 && vtype_decoded.lmul == 8 && vlen == 65536)
-            {
-            }
         }
     };
 
     VLSU::load_eew(f_readMem, VectorRegField, vtype_decoded.lmul, 1, vtype_decoded.sew / 8, vl, vlen / 8, vd, 0, vstart, pVm,
                    1);
+
+    return (0);
+}
+
+uint8_t vmts_v(void *const vector_field, uint8_t *const memory, uint16_t const vtype, uint8_t pVm, uint16_t const vs, uint8_t const Llambda,
+                            uint32_t const ld, uint32_t vstart, uint32_t const vlen, uint32_t const vl)
+{
+    auto const vtype_decoded = decode_matrix_vtype(vtype);
+    auto const effective_lambda = Llambda == 0 ? vtype_decoded.lambda : 1U << ((Llambda & 0b111) - 1);
+    auto const linesize = vtype_decoded.lmul * effective_lambda;
+    
+    auto const effective_ld = ld == 0 ? linesize : ld;
+    
+    if (effective_lambda == 0) return (1);
+    if (vl % linesize != 0) return (1);
+
+
+    uint8_t *VectorRegField;
+
+    VectorRegField = static_cast<uint8_t *>(vector_field);
+
+    std::function<void(std::size_t, uint8_t *, std::size_t)> f_writeMem =
+        [memory, vtype_decoded, linesize, effective_ld, vlen](std::size_t addr, uint8_t *buff, std::size_t len)
+    {
+        const auto base_addr = (vtype_decoded.sew / 8) * ((addr / linesize) * effective_ld + addr % linesize);
+        for (std::size_t i = 0; i < len; ++i){
+            memory[base_addr + i] = buff[i];
+        }
+    };
+
+    VLSU::store_eew(f_writeMem, VectorRegField, vtype_decoded.lmul, 1, vtype_decoded.sew / 8, vl, vlen / 8, vs, 0, vstart, pVm, 1);
 
     return (0);
 }

--- a/src/target/riscv/softmatrix.cpp
+++ b/src/target/riscv/softmatrix.cpp
@@ -20,6 +20,7 @@
 #include "softvector.h"
 #include "softfloat_types.h"
 #include "operations.hpp"
+#include "lsu/lsu.hpp"
 
 template <typename T>
 concept ValidFloatType = std::is_same_v<T, float16_t> or std::is_same_v<T, float32_t> or std::is_same_v<T, float64_t>;
@@ -103,30 +104,17 @@ inline constexpr void mmacc(T *vector_elements, unsigned vd, unsigned vs1, unsig
             // std::printf("C[%lu][%lu] =", row_C, col_C);
             for (size_t i_input = 0; i_input < K_eff; ++i_input)
             {
-                auto const vs_offset = (i_input / (lambda * widening)) * (elements_per_register * widening);
-                auto const vs_A_element = (row_C * lambda * widening) + (i_input % (lambda * widening));
-                auto const vs_B_element = (col_C * lambda * widening) + (i_input % (lambda * widening));
-                // auto const a = A_elements[vs_offset + vs_A_element];
-                // auto const b = B_elements[vs_offset + vs_B_element];
-                // std::printf("+ (v%lu[%lu] * v%lu[%lu]) ", vs1 + vs_offset, vs_A_element, vs2 + vs_offset,
-                // vs_B_element);
-
                 // std::printf("+ ([%u @ v%lu[%lu]] * [%u @ v%lu[%lu]]) ", a,
                 //             vs1 + (vs_offset / ((elements_per_register * widening))), vs_A_element, b,
                 //             vs2 + (vs_offset / ((elements_per_register * widening))), vs_B_element);
 
                 // std::printf("+ (%u * %u) ", a, b);
-                accumulator += sign_zero_extend(A_elements[vs_offset + vs_A_element], signed_A) *
-                               sign_zero_extend(B_elements[vs_offset + vs_B_element], signed_B);
+                accumulator += sign_zero_extend(A_elements[i_input + row_C * K_eff], signed_A) *
+                               sign_zero_extend(B_elements[i_input + col_C * K_eff], signed_B);
             }
 
-            auto const vd_offset = (col_C / lambda) * elements_per_register;
-            auto const vd_element = (row_C * lambda) + (col_C % lambda);
-            // std::printf("= %lu @ v%lu[%lu] \n", accumulator, vd + (vd_offset / elements_per_register), vd_element);
-            //std::printf("%lu | ", accumulator);
-            C_elements[vd_offset + vd_element] += accumulator;
+            C_elements[row_C*rows_C + col_C] += accumulator;
         }
-        // std::printf("\n\n");
     }
 }
 
@@ -139,11 +127,8 @@ inline constexpr void wmmacc(T_I *input_elements, T_O *output_elements, unsigned
     static_assert(sizeof(T_O) >= sizeof(T_I), "Illegal narrowing");
     auto const elements_per_register = vlen / sew;
 
-    // How many elements does a register contribute to a row
-    auto const row_elements_per_register = lambda * widening;
-
     // Multiplication dimension for inputs, i.e. a result element is the sum of K_eff multiplications
-    auto const K_eff = lmul * row_elements_per_register;
+    auto const K_eff = lmul * lambda * widening;
 
     // vs1 marks the start of A
     auto *const A_elements = input_elements + (vs1 * elements_per_register * widening);
@@ -164,24 +149,15 @@ inline constexpr void wmmacc(T_I *input_elements, T_O *output_elements, unsigned
             int64_t accumulator = 0;
             for (size_t i_input = 0; i_input < K_eff; ++i_input)
             {
-                auto const vs_offset = (i_input / row_elements_per_register) * (elements_per_register * widening);
-                auto const vs_A_element = (row_C * row_elements_per_register) + (i_input % row_elements_per_register);
-                auto const vs_B_element = (col_C * row_elements_per_register) + (i_input % row_elements_per_register);
-                // auto const a = A_elements[vs_offset + vs_A_element];
-                // auto const b = B_elements[vs_offset + vs_B_element];
                 // std::printf("+ ([%u @ v%lu[%lu]] * [%u @ v%lu[%lu]]) ", a,
                 //             vs1 + (vs_offset / ((elements_per_register * widening))), vs_A_element, b,
                 //             vs2 + (vs_offset / ((elements_per_register * widening))), vs_B_element);
-                accumulator += sign_zero_extend(A_elements[vs_offset + vs_A_element], signed_A) *
-                               sign_zero_extend(B_elements[vs_offset + vs_B_element], signed_B);
+                accumulator += sign_zero_extend(A_elements[i_input + row_C * K_eff], signed_A) *
+                               sign_zero_extend(B_elements[i_input + col_C * K_eff], signed_B);
             }
 
-            auto const vd_offset = (col_C / lambda) * elements_per_register;
-            auto const vd_element = (row_C * lambda) + (col_C % lambda);
-            C_elements[vd_offset + vd_element] += accumulator;
-            // std::printf("= %lu @ v%lu[%lu] \n", accumulator, vd + (vd_offset / elements_per_register), vd_element);
+            C_elements[row_C * rows_C + col_C] += accumulator;
         }
-        // std::printf("\n");
     }
 }
 
@@ -208,15 +184,15 @@ inline constexpr void mmacc_float(T *const vector_elements, unsigned vd, unsigne
 
             for (size_t i_input = 0; i_input < K_eff; ++i_input)
             {
-                auto const vs_offset = (i_input / (lambda * widening)) * (elements_per_register * widening);
-                auto const vs_A_element = (row_C * lambda * widening) + (i_input % (lambda * widening));
-                auto const vs_B_element = (col_C * lambda * widening) + (i_input % (lambda * widening));
+                //auto const vs_offset = (i_input / (lambda * widening)) * (elements_per_register * widening);
+                //auto const vs_A_element = (row_C * lambda * widening) + (i_input % (lambda * widening));
+                //auto const vs_B_element = (col_C * lambda * widening) + (i_input % (lambda * widening));
 
-                auto const vs1_index = vs1 * elements_per_register * widening + vs_offset + vs_A_element;
-                auto const vs2_index = vs2 * elements_per_register * widening + vs_offset + vs_B_element;
+                //auto const vs1_index = vs1 * elements_per_register * widening + vs_offset + vs_A_element;
+                //auto const vs2_index = vs2 * elements_per_register * widening + vs_offset + vs_B_element;
 
-                T const a = vector_elements[vs1_index];
-                T const b = vector_elements[vs2_index];
+                T const a = vector_elements[i_input + row_C * K_eff];
+                T const b = vector_elements[i_input + col_C * K_eff];
 
                 if constexpr (std::is_same_v<T, float16_t>)
                 {
@@ -370,4 +346,39 @@ uint8_t vfmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t c
     }
 
     return 0;
+}
+
+uint8_t vmtl_v(void *const vector_field, uint8_t *const memory, uint16_t const vtype, uint8_t pVm, uint16_t const vd, uint8_t const Llambda,
+                            uint32_t const ld, uint32_t vstart, uint32_t const vlen, uint32_t const vl)
+{
+    auto const vtype_decoded = decode_matrix_vtype(vtype);
+    auto const effective_lambda = Llambda == 0 ? vtype_decoded.lambda : 1U << ((Llambda & 0b111) - 1);
+    auto const linesize = vtype_decoded.lmul * effective_lambda;
+    
+    auto const effective_ld = ld == 0 ? linesize : ld;
+    
+    if (effective_lambda == 0) return (1);
+    if (vl % linesize != 0) return (1);
+
+
+    uint8_t *VectorRegField;
+
+    VectorRegField = static_cast<uint8_t *>(vector_field);
+
+    std::function<void(std::size_t, uint8_t *, std::size_t)> f_readMem =
+        [memory, vtype_decoded, linesize, effective_ld, vlen](std::size_t addr, uint8_t *buff, std::size_t len)
+    {
+        const auto base_addr = (vtype_decoded.sew / 8) * ((addr / linesize) * effective_ld + addr % linesize);
+        for (std::size_t i = 0; i < len; ++i){
+            buff[i] = memory[base_addr + i];
+            if (vtype_decoded.sew == 8 && vtype_decoded.lmul == 8 && vlen == 65536)
+            {
+            }
+        }
+    };
+
+    VLSU::load_eew(f_readMem, VectorRegField, vtype_decoded.lmul, 1, vtype_decoded.sew / 8, vl, vlen / 8, vd, 0, vstart, pVm,
+                   1);
+
+    return (0);
 }

--- a/src/target/riscv/softmatrix.cpp
+++ b/src/target/riscv/softmatrix.cpp
@@ -57,7 +57,7 @@ inline constexpr MatrixVtype decode_matrix_vtype(uint32_t vtype)
 
 template <typename T>
     requires ValidVectorElementType<T>
-inline constexpr void mmacc(T *vector_elements, unsigned vd, unsigned vs1, unsigned vs2, unsigned vlen, unsigned lambda,
+inline constexpr void mmacc(T *vector_elements, unsigned vd, unsigned vs1, unsigned vs2, unsigned vlen, unsigned vl, unsigned lambda,
                             unsigned lmul, unsigned sew, unsigned widening, bool signed_A, bool signed_B)
 {
     // Accumulator is always signed
@@ -84,18 +84,20 @@ inline constexpr void mmacc(T *vector_elements, unsigned vd, unsigned vs1, unsig
     // vd marks the start of C
     auto *const C_elements = output_elements + (vd * elements_per_register);
 
-    // Rows & columns of C
+    // Rows of C
     // Dimensions of C, M = N,
     // = ((LMUL * VLEN) / (SEW / W)) / K_eff                | Move W to numerator
     // = ((LMUL * VLEN * W) / SEW) / K_eff                  | Replace K_eff with definition
     // = ((LMUL * VLEN * W) / SEW) / (Lambda * W * LMUL)    | Cross out LMUL & W
     // = (VLEN / SEW) / Lambda
-    auto const dim_C = elements_per_register / lambda;
+    auto const rows_C = elements_per_register / lambda;
+    // cols of C
+    auto const cols_C = vl / (lambda * lmul);
     // std::printf("E per R %u, dim C %u, lambda %u\n", elements_per_register, dim_C, lambda);
 
-    for (size_t row_C = 0; row_C < dim_C; ++row_C)
+    for (size_t row_C = 0; row_C < rows_C; ++row_C)
     {
-        for (size_t col_C = 0; col_C < dim_C; ++col_C)
+        for (size_t col_C = 0; col_C < cols_C; ++col_C)
         {
             int64_t accumulator = 0;
             // std::printf("C[%lu][%lu] =", row_C, col_C);
@@ -121,7 +123,7 @@ inline constexpr void mmacc(T *vector_elements, unsigned vd, unsigned vs1, unsig
             auto const vd_offset = (col_C / lambda) * elements_per_register;
             auto const vd_element = (row_C * lambda) + (col_C % lambda);
             // std::printf("= %lu @ v%lu[%lu] \n", accumulator, vd + (vd_offset / elements_per_register), vd_element);
-            // std::printf("%lu | ", accumulator);
+            //std::printf("%lu | ", accumulator);
             C_elements[vd_offset + vd_element] += accumulator;
         }
         // std::printf("\n\n");
@@ -131,7 +133,7 @@ inline constexpr void mmacc(T *vector_elements, unsigned vd, unsigned vs1, unsig
 template <typename T_I, typename T_O>
     requires ValidVectorElementType<T_I>
 inline constexpr void wmmacc(T_I *input_elements, T_O *output_elements, unsigned vd, unsigned vs1, unsigned vs2,
-                             unsigned vlen, unsigned lambda, unsigned lmul, unsigned sew, bool signed_A, bool signed_B)
+                             unsigned vlen, unsigned vl, unsigned lambda, unsigned lmul, unsigned sew, bool signed_A, bool signed_B)
 {
     constexpr auto widening = sizeof(T_O) / sizeof(T_I);
     static_assert(sizeof(T_O) >= sizeof(T_I), "Illegal narrowing");
@@ -150,12 +152,13 @@ inline constexpr void wmmacc(T_I *input_elements, T_O *output_elements, unsigned
     // vd marks the start of C
     auto *const C_elements = output_elements + (vd * elements_per_register);
 
-    // Rows & columns of C
-    auto const dim_C = elements_per_register / lambda;
+    // Rows of C
+    auto const rows_C = elements_per_register / lambda;
+    auto const cols_C = vl / (lambda * lmul);
 
-    for (size_t row_C = 0; row_C < dim_C; ++row_C)
+    for (size_t row_C = 0; row_C < rows_C; ++row_C)
     {
-        for (size_t col_C = 0; col_C < dim_C; ++col_C)
+        for (size_t col_C = 0; col_C < cols_C; ++col_C)
         {
             // std::printf("C[%lu][%lu] =", row_C, col_C);
             int64_t accumulator = 0;
@@ -184,16 +187,18 @@ inline constexpr void wmmacc(T_I *input_elements, T_O *output_elements, unsigned
 
 template <typename T>
     requires ValidFloatType<T>
-inline constexpr void mmacc_float(T *const vector_elements, unsigned vd, unsigned vs1, unsigned vs2, unsigned vlen,
+inline constexpr void mmacc_float(T *const vector_elements, unsigned vd, unsigned vs1, unsigned vs2, unsigned vlen, unsigned vl,
                                   unsigned lambda, unsigned lmul, unsigned sew, unsigned widening)
 {
     auto const elements_per_register = vlen / sew;
     auto const K_eff = lambda * widening * lmul;
-    auto const dim_C = elements_per_register / lambda;
+    auto const rows_C = elements_per_register / lambda;
+    auto const cols_C = vl / (lambda * lmul);
+    
 
-    for (size_t row_C = 0; row_C < dim_C; ++row_C)
+    for (size_t row_C = 0; row_C < rows_C; ++row_C)
     {
-        for (size_t col_C = 0; col_C < dim_C; ++col_C)
+        for (size_t col_C = 0; col_C < cols_C; ++col_C)
         {
             auto const vd_offset = (col_C / lambda) * elements_per_register;
             auto const vd_element = (row_C * lambda) + (col_C % lambda);
@@ -234,7 +239,7 @@ inline constexpr void mmacc_float(T *const vector_elements, unsigned vd, unsigne
 
 // Single width MMACC
 uint8_t vmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
-                  uint16_t const vs2, uint16_t const vstart, uint32_t const vlen)
+                  uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl)
 {
     auto const vtype_decoded = decode_matrix_vtype(vtype);
     // auto punner = PointerPunner(vector_field);
@@ -253,19 +258,19 @@ uint8_t vmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t co
     switch (sew)
     {
     case 8:
-        mmacc<uint8_t>(reinterpret_cast<uint8_t *>(vector_field), vd, vs1, vs2, vlen, lambda, lmul, sew, widening,
+        mmacc<uint8_t>(reinterpret_cast<uint8_t *>(vector_field), vd, vs1, vs2, vlen, vl, lambda, lmul, sew, widening,
                        !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     case 16:
-        mmacc<uint16_t>(reinterpret_cast<uint16_t *>(vector_field), vd, vs1, vs2, vlen, lambda, lmul, sew, widening,
+        mmacc<uint16_t>(reinterpret_cast<uint16_t *>(vector_field), vd, vs1, vs2, vlen, vl, lambda, lmul, sew, widening,
                         !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     case 32:
-        mmacc<uint32_t>(reinterpret_cast<uint32_t *>(vector_field), vd, vs1, vs2, vlen, lambda, lmul, sew, widening,
+        mmacc<uint32_t>(reinterpret_cast<uint32_t *>(vector_field), vd, vs1, vs2, vlen, vl, lambda, lmul, sew, widening,
                         !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     case 64:
-        mmacc<uint64_t>(reinterpret_cast<uint64_t *>(vector_field), vd, vs1, vs2, vlen, lambda, lmul, sew, widening,
+        mmacc<uint64_t>(reinterpret_cast<uint64_t *>(vector_field), vd, vs1, vs2, vlen, vl, lambda, lmul, sew, widening,
                         !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     default:
@@ -278,7 +283,7 @@ uint8_t vmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t co
 
 // Double-widening MMACC
 uint8_t vwmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
-                   uint16_t const vs2, uint16_t const vstart, uint32_t const vlen)
+                   uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl)
 {
     auto const vtype_decoded = decode_matrix_vtype(vtype);
     auto const sew = vtype_decoded.sew;
@@ -288,16 +293,16 @@ uint8_t vwmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t c
     switch (sew)
     {
     case 16:
-        wmmacc(reinterpret_cast<uint8_t *>(vector_field), reinterpret_cast<int16_t *>(vector_field), vd, vs1, vs2, vlen,
+        wmmacc(reinterpret_cast<uint8_t *>(vector_field), reinterpret_cast<int16_t *>(vector_field), vd, vs1, vs2, vlen, vl,
                lambda, lmul, sew, !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     case 32:
         wmmacc(reinterpret_cast<uint16_t *>(vector_field), reinterpret_cast<int32_t *>(vector_field), vd, vs1, vs2,
-               vlen, lambda, lmul, sew, !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
+               vlen, vl, lambda, lmul, sew, !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     case 64:
         wmmacc(reinterpret_cast<uint32_t *>(vector_field), reinterpret_cast<int64_t *>(vector_field), vd, vs1, vs2,
-               vlen, lambda, lmul, sew, !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
+               vlen, vl, lambda, lmul, sew, !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     default:
         // Illegal SEW
@@ -309,7 +314,7 @@ uint8_t vwmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t c
 
 // Quad-widening MMACC
 uint8_t vqwmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
-                    uint16_t const vs2, uint16_t const vstart, uint32_t const vlen)
+                    uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl)
 {
     auto const vtype_decoded = decode_matrix_vtype(vtype);
     auto const sew = vtype_decoded.sew;
@@ -319,12 +324,12 @@ uint8_t vqwmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t 
     switch (sew)
     {
     case 32:
-        wmmacc(reinterpret_cast<uint8_t *>(vector_field), reinterpret_cast<int32_t *>(vector_field), vd, vs1, vs2, vlen,
+        wmmacc(reinterpret_cast<uint8_t *>(vector_field), reinterpret_cast<int32_t *>(vector_field), vd, vs1, vs2, vlen, vl,
                lambda, lmul, sew, !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     case 64:
         wmmacc(reinterpret_cast<uint16_t *>(vector_field), reinterpret_cast<int64_t *>(vector_field), vd, vs1, vs2,
-               vlen, lambda, lmul, sew, !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
+               vlen, vl, lambda, lmul, sew, !vtype_decoded.altfmt_A, !vtype_decoded.altfmt_B);
         break;
     default:
         // Illegal SEW
@@ -335,7 +340,7 @@ uint8_t vqwmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t 
 }
 
 uint8_t vfmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t const vd, uint16_t const vs1,
-                   uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint8_t const rounding_mode)
+                   uint16_t const vs2, uint16_t const vstart, uint32_t const vlen, uint32_t const vl, uint8_t const rounding_mode)
 {
     auto const vtype_decoded = decode_matrix_vtype(vtype);
     auto const sew = vtype_decoded.sew;
@@ -349,15 +354,15 @@ uint8_t vfmmacc_vv(uint8_t *const vector_field, uint32_t const vtype, uint16_t c
     switch (sew)
     {
     case 16:
-        mmacc_float<float16_t>(reinterpret_cast<float16_t *>(vector_field), vd, vs1, vs2, vlen, lambda, lmul, sew,
+        mmacc_float<float16_t>(reinterpret_cast<float16_t *>(vector_field), vd, vs1, vs2, vlen, vl, lambda, lmul, sew,
                                widening);
         break;
     case 32:
-        mmacc_float<float32_t>(reinterpret_cast<float32_t *>(vector_field), vd, vs1, vs2, vlen, lambda, lmul, sew,
+        mmacc_float<float32_t>(reinterpret_cast<float32_t *>(vector_field), vd, vs1, vs2, vlen, vl, lambda, lmul, sew,
                                widening);
         break;
     case 64:
-        mmacc_float<float64_t>(reinterpret_cast<float64_t *>(vector_field), vd, vs1, vs2, vlen, lambda, lmul, sew,
+        mmacc_float<float64_t>(reinterpret_cast<float64_t *>(vector_field), vd, vs1, vs2, vlen, vl, lambda, lmul, sew,
                                widening);
         break;
     default:

--- a/test/target/riscv/soft/matrix_helpers.hpp
+++ b/test/target/riscv/soft/matrix_helpers.hpp
@@ -110,9 +110,10 @@ void convert(T *const vector_elements, unsigned const lambda, unsigned const vle
         for (size_t col = 0; col < cols; ++col)
         {
             auto const used_col = trans ? row : col;
+            auto const used_cols = trans ? rows : cols;
             auto const used_row = trans ? col : row;
-            auto const vreg = used_col / row_elems_per_register;
-            auto const velem = (used_row * row_elems_per_register) + used_col % row_elems_per_register;
+            auto const vreg = (used_row * used_cols + used_col) / elements_per_register;
+            auto const velem = (used_row * used_cols + used_col) % elements_per_register;
             if (to_serial)
             {
                 serial.push_back(vector_elements[v_base + (vreg * elements_per_register) + velem]);
@@ -179,15 +180,15 @@ void print_rv_matrix(T *const vector_elements, unsigned const lambda, unsigned c
 
     auto const cols = lmul * row_elems_per_register;
     auto const rows = total_elements / cols;
-    std::printf("%u cols, %lu rows\n", cols, rows);
     for (size_t row = 0; row < rows; ++row)
     {
         for (size_t col = 0; col < cols; ++col)
         {
             auto const used_col = trans ? row : col;
+            auto const used_cols = trans ? rows : cols;
             auto const used_row = trans ? col : row;
-            auto const vreg = used_col / row_elems_per_register;
-            auto const velem = (used_row * row_elems_per_register) + (used_col % row_elems_per_register);
+            auto const vreg = (used_row * used_cols + used_col) / elements_per_register;
+            auto const velem = (used_row * used_cols + used_col) % elements_per_register;
             // auto const v_offset = (used_col / (lambda * widening)) * elements_per_register;
             // auto const v_element = (used_row * (lambda * widening)) + (used_col % (lambda * widening));
             if constexpr (std::is_signed_v<T>)
@@ -280,8 +281,8 @@ void seq_fill(std::vector<T> &vec, unsigned lmul, unsigned lambda, unsigned wide
     {
         for (size_t col = 0; col < cols; ++col)
         {
-            auto const vreg = col / row_elms_per_register;
-            auto const velem = (row * row_elms_per_register) + (col % row_elms_per_register);
+            auto const vreg = (row * cols + col) / elms_per_register;
+            auto const velem = (row * cols + col) % elms_per_register;
             auto const fill_val = vreg * elms_per_register + velem;
             // auto const fill_val = (col % (lambda * widening)) + (row * lambda * widening) +
             //                       (((col / (lambda * widening)) * rows) * lambda);

--- a/test/target/riscv/soft/matrix_helpers.hpp
+++ b/test/target/riscv/soft/matrix_helpers.hpp
@@ -50,7 +50,7 @@ inline constexpr auto LAMBDA_64 = 0b111;
 template <typename T>
 inline constexpr auto sign_zero_extend(T value, bool is_signed) -> uint64_t
 {
-    static constexpr auto width = sizeof(T) * 8;
+    constexpr auto width = sizeof(T) * 8;
     static_assert(width <= 64);
     return static_cast<uint64_t>(((static_cast<int64_t>(value) << (64 - width)) >> (64 - width)) * is_signed) |
            (static_cast<uint64_t>(value) * !is_signed);

--- a/test/target/riscv/soft/matrix_test.cpp
+++ b/test/target/riscv/soft/matrix_test.cpp
@@ -305,7 +305,7 @@ bool seq_increase_test_quad(unsigned sew, unsigned lmul, unsigned lambda, unsign
 
 template <typename T>
     requires std::is_integral_v<T>
-bool load_test(unsigned sew, unsigned lmul, unsigned lambda, unsigned vd, unsigned vlen)
+bool load_store_test(unsigned sew, unsigned lmul, unsigned lambda, unsigned vd, unsigned vlen)
 {
     auto const vtype = encode_matrix_vtype(sew, lmul, lambda, 0, 0, false);
     auto const decoded_vtype = decode_matrix_vtype(vtype);
@@ -315,12 +315,17 @@ bool load_test(unsigned sew, unsigned lmul, unsigned lambda, unsigned vd, unsign
 
     // create array of memory to load from ( dont use vector!)
     std::vector<ResultType> C;
-    C.reserve(elements_per_register * lmul);
+    C.reserve(elements_per_register * decoded_vtype.lmul);
     seq_fill(C, decoded_vtype.lmul, decoded_vtype.lambda, 1,
              elements_per_register * decoded_vtype.lmul);
 
     auto const res = vmtl_v(
         vector_field.data(), reinterpret_cast<uint8_t *>(&C[0]), vtype, sizeof(T), vd, lambda,
+        decoded_vtype.lmul*decoded_vtype.lambda, 0, vlen, vlen/decoded_vtype.sew * decoded_vtype.lmul);
+
+    std::vector<ResultType> C_from_RV_store(elements_per_register * decoded_vtype.lmul, 0);
+    auto const res2 = vmts_v(
+        vector_field.data(), reinterpret_cast<uint8_t *>(&C_from_RV_store[0]), vtype, 1, vd, lambda,
         decoded_vtype.lmul*decoded_vtype.lambda, 0, vlen, vlen/decoded_vtype.sew * decoded_vtype.lmul);
 
     //print_rv_matrix(reinterpret_cast<ResultType *>(vector_field.data()), decoded_vtype.lambda, vlen, vd, 1, decoded_vtype.lmul, false);
@@ -338,6 +343,12 @@ bool load_test(unsigned sew, unsigned lmul, unsigned lambda, unsigned vd, unsign
         print_matrix(C, decoded_vtype.lambda, decoded_vtype.lmul, 1);
         std::printf("C from RV\n");
         print_matrix(C_from_RV, decoded_vtype.lambda, decoded_vtype.lmul, 1);
+        std::exit(EXIT_FAILURE);
+    } else if (!is_equal(C, C_from_RV_store)) {
+        std::printf("Stored Result not equal to golden result!\n");
+        print_matrix(C, decoded_vtype.lambda, decoded_vtype.lmul, 1);
+        printf("\n\n\n\n");
+        print_matrix(C_from_RV_store, decoded_vtype.lambda, decoded_vtype.lmul, 1);
         std::exit(EXIT_FAILURE);
     }
     else
@@ -380,16 +391,16 @@ int main()
                     switch (sew)
                     {
                     case SEW_E8:
-                        load_test<uint8_t>(sew, lmul, lambda , 0, vlen);
+                        load_store_test<uint8_t>(sew, lmul, lambda , 0, vlen);
                         break;
                     case SEW_E16:
-                        load_test<uint16_t>(sew, lmul, lambda , 0, vlen);
+                        load_store_test<uint16_t>(sew, lmul, lambda , 0, vlen);
                         break;
                     case SEW_E32:
-                        load_test<uint32_t>(sew, lmul, lambda , 0, vlen);
+                        load_store_test<uint32_t>(sew, lmul, lambda , 0, vlen);
                         break;
                     case SEW_E64:
-                        load_test<uint64_t>(sew, lmul, lambda , 0, vlen);
+                        load_store_test<uint64_t>(sew, lmul, lambda , 0, vlen);
                         break;
                     default:
                         break;

--- a/test/target/riscv/soft/matrix_test.cpp
+++ b/test/target/riscv/soft/matrix_test.cpp
@@ -125,6 +125,7 @@ bool seq_increase_test(unsigned sew, unsigned lmul, unsigned lambda, unsigned vd
         // print_matrix(C_from_RV, decoded_vtype.lambda, mul_C, 1);
         // std::printf("RV\n");
         // print_rv_matrix(vector_field.data(), decoded_vtype.lambda, vlen, vd, 1, mul_C, false);
+        std::exit(EXIT_FAILURE);
     }
     else
     {
@@ -172,6 +173,7 @@ bool seq_increase_test_double(unsigned sew, unsigned lmul, unsigned lambda, unsi
     vid_v(vector_field.data(), static_cast<uint16_t>(vtype_vid), 1, vs2, 0, vlen,
           elements_per_register * decoded_vtype.lmul * widening);
 
+
     // Golden
     seq_fill(A, decoded_vtype.lmul, decoded_vtype.lambda, widening,
              elements_per_register * decoded_vtype.lmul * widening);
@@ -189,8 +191,6 @@ bool seq_increase_test_double(unsigned sew, unsigned lmul, unsigned lambda, unsi
     auto is_ok = is_equal(C, C_from_RV);
     if (!is_ok)
     {
-        std::printf("DOUBLE: Result not equal to golden result!\n");
-
         std::printf("A\n");
         print_matrix(A, decoded_vtype.lambda, decoded_vtype.lmul, widening);
         std::printf("ARV\n");
@@ -199,8 +199,8 @@ bool seq_increase_test_double(unsigned sew, unsigned lmul, unsigned lambda, unsi
         print_matrix(B, decoded_vtype.lambda, decoded_vtype.lmul, widening);
         std::printf("C\n");
         print_matrix(C, decoded_vtype.lambda, mul_C, 1);
-        std::printf("C from RV\n");
-        print_matrix(C_from_RV, decoded_vtype.lambda, mul_C, 1);
+        //std::printf("C from RV\n");
+        //print_matrix(C_from_RV, decoded_vtype.lambda, mul_C, 1);
         std::printf("RV\n");
         print_rv_matrix(reinterpret_cast<ResultType *>(vector_field.data()), decoded_vtype.lambda, vlen, vd, 1, mul_C,
                         false);
@@ -302,6 +302,52 @@ bool seq_increase_test_quad(unsigned sew, unsigned lmul, unsigned lambda, unsign
     return is_ok;
 }
 
+
+template <typename T>
+    requires std::is_integral_v<T>
+bool load_test(unsigned sew, unsigned lmul, unsigned lambda, unsigned vd, unsigned vlen)
+{
+    auto const vtype = encode_matrix_vtype(sew, lmul, lambda, 0, 0, false);
+    auto const decoded_vtype = decode_matrix_vtype(vtype);
+    auto const elements_per_register = vlen / decoded_vtype.sew;
+    
+    using ResultType = std::make_signed_t<T>;
+
+    // create array of memory to load from ( dont use vector!)
+    std::vector<ResultType> C;
+    C.reserve(elements_per_register * lmul);
+    seq_fill(C, decoded_vtype.lmul, decoded_vtype.lambda, 1,
+             elements_per_register * decoded_vtype.lmul);
+
+    auto const res = vmtl_v(
+        vector_field.data(), reinterpret_cast<uint8_t *>(&C[0]), vtype, sizeof(T), vd, lambda,
+        decoded_vtype.lmul*decoded_vtype.lambda, 0, vlen, vlen/decoded_vtype.sew * decoded_vtype.lmul);
+
+    //print_rv_matrix(reinterpret_cast<ResultType *>(vector_field.data()), decoded_vtype.lambda, vlen, vd, 1, decoded_vtype.lmul, false);
+
+    std::vector<ResultType> C_from_RV;
+
+    convert(reinterpret_cast<ResultType *>(vector_field.data()), decoded_vtype.lambda, vlen, vd, 1, decoded_vtype.lmul, false,
+            C_from_RV, true);
+    
+    auto is_ok = is_equal(C, C_from_RV);
+    if (!is_ok)
+    {
+        std::printf("Loaded Result not equal to golden result!\n");
+        std::printf("C\n");
+        print_matrix(C, decoded_vtype.lambda, decoded_vtype.lmul, 1);
+        std::printf("C from RV\n");
+        print_matrix(C_from_RV, decoded_vtype.lambda, decoded_vtype.lmul, 1);
+        std::exit(EXIT_FAILURE);
+    }
+    else
+    {
+        std::printf("\t%sLOAD : Test success%s\n", GREEN, RESET);
+    }
+    zero_vectors(vector_field.data(), vector_field.size());
+    return is_ok;
+}
+
 struct Signs
 {
     bool signed_A = false;
@@ -322,19 +368,36 @@ int main()
             for (auto &&lambda : lambdas)
             {
                 for (auto &&sew : sews)
-                {
+                {   
+                    auto const sew_val = 8U << sew;
+                    auto const elements_per_register = vlen / sew_val;
+                    auto const lambda_val = 1U << (lambda - 1);
+                    auto const mul_C = elements_per_register / (lambda_val * lambda_val);
+                    if (!check_mul_C(mul_C))
+                    {
+                        continue;
+                    }
+                    switch (sew)
+                    {
+                    case SEW_E8:
+                        load_test<uint8_t>(sew, lmul, lambda , 0, vlen);
+                        break;
+                    case SEW_E16:
+                        load_test<uint16_t>(sew, lmul, lambda , 0, vlen);
+                        break;
+                    case SEW_E32:
+                        load_test<uint32_t>(sew, lmul, lambda , 0, vlen);
+                        break;
+                    case SEW_E64:
+                        load_test<uint64_t>(sew, lmul, lambda , 0, vlen);
+                        break;
+                    default:
+                        break;
+                    }
                     for (int signed_A = 0; signed_A < 2; signed_A++)
                     {
                         for (int signed_B = 0; signed_B < 2; signed_B++)
                         {
-                            auto const sew_val = 8U << sew;
-                            auto const elements_per_register = vlen / sew_val;
-                            auto const lambda_val = 1U << (lambda - 1);
-                            auto const mul_C = elements_per_register / (lambda_val * lambda_val);
-                            if (!check_mul_C(mul_C))
-                            {
-                                continue;
-                            }
                             std::printf("SEW: %u, LMUL: %u, LAMBDA: %u, VLEN: %u, A %s, B %s\n", sew_val, 1U << lmul,
                                         lambda_val, vlen, signed_A ? "signed" : "unsigned",
                                         signed_B ? "signed" : "unsigned");

--- a/test/target/riscv/soft/matrix_test.cpp
+++ b/test/target/riscv/soft/matrix_test.cpp
@@ -102,7 +102,7 @@ bool seq_increase_test(unsigned sew, unsigned lmul, unsigned lambda, unsigned vd
     seq_fill(B, decoded_vtype.lmul, decoded_vtype.lambda, 1, elements_per_register * decoded_vtype.lmul);
 
     // MMACC
-    vmmacc_vv(vector_field.data(), vtype, vd, vs1, vs2, 0, vlen);
+    vmmacc_vv(vector_field.data(), vtype, vd, vs1, vs2, 0, vlen, elements_per_register * decoded_vtype.lmul);
     mmacc(A, B, C, decoded_vtype.lmul, decoded_vtype.lambda, 1, signed_A, signed_B);
 
     std::vector<ResultType> C_from_RV;
@@ -179,7 +179,7 @@ bool seq_increase_test_double(unsigned sew, unsigned lmul, unsigned lambda, unsi
              elements_per_register * decoded_vtype.lmul * widening);
 
     // MMACC
-    vwmmacc_vv(vector_field.data(), vtype_wmmacc, vd, vs1, vs2, 0, vlen);
+    vwmmacc_vv(vector_field.data(), vtype_wmmacc, vd, vs1, vs2, 0, vlen, elements_per_register * decoded_vtype.lmul);
     mmacc(A, B, C, decoded_vtype.lmul, decoded_vtype.lambda, widening, signed_A, signed_B);
 
     std::vector<ResultType> C_from_RV;
@@ -263,7 +263,7 @@ bool seq_increase_test_quad(unsigned sew, unsigned lmul, unsigned lambda, unsign
              elements_per_register * decoded_vtype.lmul * widening);
 
     // MMACC
-    vqwmmacc_vv(vector_field.data(), vtype_qwmmacc, vd, vs1, vs2, 0, vlen);
+    vqwmmacc_vv(vector_field.data(), vtype_qwmmacc, vd, vs1, vs2, 0, vlen, elements_per_register* decoded_vtype.lmul);
     mmacc(A, B, C, decoded_vtype.lmul, decoded_vtype.lambda, widening, signed_A, signed_B);
 
     std::vector<ResultType> C_from_RV;


### PR DESCRIPTION
This fixes the matrix multiply code.  It previously did not take into account the current VL setting, which selects the active columns of the B (and consequently C) tiles, see the  [instruction manual](https://github.com/riscv/integrated-matrix-extension/releases/download/riscv-isa-release-dad9550-2026-07-26/riscv-unprivileged.html) at section "36.11.9. vmmacc.vv"

Please note this breaks the current etiss architecture in etiss_rvv RV32IMACFDV_zvl1024b. I have already fixed this locally and will push changes soon.

Some testcases should be added to properly test this behavior. I have conducted these, but not included them in this PR since they are outside the scope of this repository.